### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://tolstenko.visualstudio.com/60e1e6f7-bcb3-4db0-933d-654233df5192/a21e0e5b-7dce-4525-96c1-744e51d8890c/_apis/work/boardbadge/da22df66-f764-48e7-b577-d3d288d67897)](https://tolstenko.visualstudio.com/60e1e6f7-bcb3-4db0-933d-654233df5192/_boards/board/t/a21e0e5b-7dce-4525-96c1-744e51d8890c/Microsoft.RequirementCategory)
 ![](./assets/logo.png)
 
 Welcome to the **MoBaGEn**. The **MO**dule **BA**sed **G**ame **EN**gine. 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#10](https://tolstenko.visualstudio.com/60e1e6f7-bcb3-4db0-933d-654233df5192/_workitems/edit/10). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.